### PR TITLE
Upgrade data

### DIFF
--- a/src/impl/http_parser/lolevel/HTTPParser.java
+++ b/src/impl/http_parser/lolevel/HTTPParser.java
@@ -146,6 +146,7 @@ public class  HTTPParser {
 
     // this is where the work gets done, traverse the available data...
     while (data.position() != data.limit()) {
+      if (upgrade) break;
 
             p = data.position();
       int  pe = data.limit();


### PR DESCRIPTION
When playing with an upgrade connection I was receiving an error about the headers being incomplete if there was third key data after the headers. Breaking out of the while fixes the issue.

I wasn't able to figure out how the tests work in order to add a test fo the third key. An example is:

```
 GET /demo HTTP/1.1\r\n
 Connection: Upgrade\r\n
 Upgrade: WebSocket\r\n\r\n
 third key data"
```
